### PR TITLE
Change matching rules

### DIFF
--- a/wisecreator/book.py
+++ b/wisecreator/book.py
@@ -34,7 +34,7 @@ class RawmlRarser(HTMLParser):
 
     def handle_data(self, data):
         paragraph_text = data
-        for match in re.finditer(r'[A-Za-z\']+', paragraph_text):
+        for match in re.finditer(r'[A-Za-z\'-]+', paragraph_text):
             word = paragraph_text[match.start():match.end()]
             word_offset = self.getpos()[1] + match.start()
             word_byte_offset = self.last_token_bt_offset + len(


### PR DESCRIPTION
This rule will ignore words like 'emerald-green' rather than show the meaning of 'emerald'.

I have tried to add value `end` to recognize 'emerald-green' as 'emerald', but it didn't work.