### PR TITLE
fix linux 32 64bit system and add execute permission to mobitool

### DIFF
--- a/wisecreator/main.py
+++ b/wisecreator/main.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 import sys
+import stat
 import shutil
 import sqlite3
 import logging
@@ -34,12 +35,18 @@ def get_path_to_mobitool():
 
     path_to_mobitool = ""
     if platform.system() == "Linux":
-        path_to_mobitool = os.path.join(path_to_third_party, "mobitool-linux-i386")
+        if sys.maxsize > 2**32:
+            path_to_mobitool = os.path.join(path_to_third_party, "mobitool-linux-x86_64")
+        else:
+            path_to_mobitool = os.path.join(path_to_third_party, "mobitool-linux-i386")
     if platform.system() == "Windows":
         path_to_mobitool = os.path.join(path_to_third_party, "mobitool-win32.exe")
     if platform.system() == "Darwin":
         path_to_mobitool = os.path.join(path_to_third_party, "mobitool-osx-x86_64")
 
+    # add executed permission
+    current_permission = os.stat(path_to_mobitool)
+    os.chmod(path_to_mobitool, current_permission.st_mode | stat.S_IEXEC)
     return path_to_mobitool
 
 


### PR DESCRIPTION
1. When running tool from source, i see the bug: "Errno 13: Permission denied: '~/wisecreator/venv/lib/python3.8/site-packages/wisecreator/third_party/mobitool-linux-i386" due to lacking execute permission of mobitool-linux package. Then i add the permission and everything is okay
2. Also i matched mobitool path correctly to OS architecture. 32bit use i386 and 64bit use x86_64 package
