### PR TITLE
CHORE: fix some issues to run with Python 3.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ venv.bak/
 .vscode/
 
 wiki/
+
+/test\ books/*-WordWised

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ def install_nltk_data():
     import nltk
     nltk.download('wordnet')
     nltk.download('averaged_perceptron_tagger')
+    nltk.download('averaged_perceptron_tagger_eng')
 
 class PostDevelopCommand(develop):
     def run(self):
@@ -20,20 +21,20 @@ class PostInstallCommand(install):
 setup(
     name='wisecreator',
     version='1.0.0',
-    python_requires='>=3.6',
+    python_requires='>=3.13',
     author='Timofey Milovanov',
     packages=['wisecreator'],
     package_data={
         'wisecreator':['data/*', 'third_party/*']
     },
     install_requires=[
-        'nltk==3.4.5',
+        'nltk==3.9.1',
         'cursor==1.3.4',
-        'six==1.12.0',
+        'six==1.17.0',
         'dataclasses',
     ],
     setup_requires=[
-        'nltk==3.4.5',
+        'nltk==3.9.1',
     ],
     cmdclass={
       'install': PostInstallCommand,


### PR DESCRIPTION
Changes:
- Add `nltk.download('averaged_perceptron_tagger_eng')` to support for English.
- Bump the `nltk` to version 3.9.1 (A Python function deprecated, which is not working on Python 3.13).
- 